### PR TITLE
chore: 🤖 remove unused bookmark column

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -77,9 +77,7 @@ const Routes = ({
     >
       <Switch>
         <Route path={RouteNames.AppTransactions}>
-          <LazyAppTransactions
-            bookmarkColumnMode={bookmarkColumnMode}
-          />
+          <LazyAppTransactions />
         </Route>
         <Route path={RouteNames.Home}>
           <LazyOverview
@@ -94,14 +92,6 @@ const Routes = ({
 
 const App = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [
-    bookmarkColumnMode,
-    setBookmarkColumnMode,
-  ] = useState<BookmarkColumnModes>(BookmarkColumnModes.collapsed);
-  const bookmarkExpandHandler = useCallback(createBookmarkExpandHandler({
-    bookmarkColumnMode,
-    setBookmarkColumnMode,
-  }), [bookmarkColumnMode, setBookmarkColumnMode]);
 
   // Mocks async initial request
   useEffect(() => {
@@ -111,8 +101,8 @@ const App = () => {
   return (
     <Router>
       <Routes
-        bookmarkColumnMode={bookmarkColumnMode}
-        bookmarkExpandHandler={bookmarkExpandHandler}
+        bookmarkColumnMode={BookmarkColumnModes.collapsed}
+        bookmarkExpandHandler={() => null}
         loading={isLoading}
       />
     </Router>

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -17,16 +17,10 @@ import {
 } from '@psychedelic/cap-js';
 import { scrollTop } from '@utils/window';
 
-const AppTransactions = ({
-  bookmarkColumnMode,
-}: {
-  bookmarkColumnMode: BookmarkColumnModes,
-}) => {
+const AppTransactions = () => {
   const {
     pageData,
     fetch,
-    // transactionEvents,
-    // totalTransactions,
     totalPages,
     reset,
   } = useTransactionStore((state) => state);


### PR DESCRIPTION
## Why?

The Bookmark column is not in use and as such, should be removed.

⚠️ Depends on https://github.com/Psychedelic/cap-explorer/pull/6
