### PR TITLE
chore: 🤖 add breadcrumbs to the app transactions view

### DIFF
--- a/packages/dashboard/src/components/Breadcrumb/index.tsx
+++ b/packages/dashboard/src/components/Breadcrumb/index.tsx
@@ -47,7 +47,8 @@ const Breadcrumb = ({ id }: BreadcrumbProps) => {
     <Container
       data-id="breadcrumb"
     >
-      <span>Accounts</span>
+      <span>Overview</span>
+      {/* TODO: Use DabJS to get token contract name */}
       <span>{isSmallerThanBreakpointLG ? trimAccount(id) : id }</span>
     </Container>
   );

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import TransactionsTable, { FetchPageDataHandler } from '@components/Tables/TransactionsTable';
-import {
-  BookmarkColumnModes,
-} from '@components/BookmarkPanel';
+import Breadcrumb from '@components/Breadcrumb';
 import Title from '@components/Title';
 import Page, { PageRow } from '@components/Page';
 import {
@@ -57,6 +55,9 @@ const AppTransactions = () => {
     <Page
       pageId="app-transactions-page"
     >
+      <PageRow>
+        <Breadcrumb id={tokenId} />
+      </PageRow>
       <PageRow>
         <Title size="xl">{`Transactions for ${trimAccount(tokenId)}`}</Title>
       </PageRow>


### PR DESCRIPTION
## Why?

In accordance to the Figma design, a breadcrumb should exist at the top of the transactions page.
