### PR TITLE
refactor: 💡 renamed field as cap root

### DIFF
--- a/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
@@ -51,7 +51,7 @@ const columns: Column[] = [
     accessor: 'name',
   },
   {
-    Header: 'Canister ID',
+    Header: 'Cap Root',
     accessor: 'canister',
   },
 ];


### PR DESCRIPTION
## Why?

The Overview/Accounts table should show Cap Root instead of Canister Id
