### PR TITLE
refactor: 💡 moves the dependencies of generate random principal

### DIFF
--- a/packages/generate-random-principal/package.json
+++ b/packages/generate-random-principal/package.json
@@ -16,9 +16,7 @@
   "author": "Helder Oliveira",
   "dependencies": {
     "@dfinity/identity": "^0.10.1",
-    "@dfinity/principal": "^0.10.1"
-  },
-  "devDependencies": {
+    "@dfinity/principal": "^0.10.1",
     "@types/node": "^16.11.4",
     "typescript": "^4.4.4",
     "process": "^0.11.10"


### PR DESCRIPTION
## Why?

The generate random principal dependencies should be in dependencies and not devDependencies.
