### PR TITLE
chore: 🤖 only show memo which are numbers (#47)

### DIFF
--- a/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
@@ -221,7 +221,7 @@ const TransactionsTable = ({
       },
       time: (cellValue: string) => dateRelative(cellValue),
       memo: (cellValue: string) => {
-        if (!cellValue) return 'n/a';
+        if (!cellValue || typeof cellValue !== 'number') return 'n/a';
         return Number(cellValue)
       },
     },


### PR DESCRIPTION
## Why?

A small release to bring the column `memo` fix.