### PR TITLE
fix: 🐛 function signature expects one argument

### DIFF
--- a/packages/dashboard/src/utils/dab.ts
+++ b/packages/dashboard/src/utils/dab.ts
@@ -36,7 +36,10 @@ export const getDabMetadata = async ({
     const agent = new HttpAgent(httpAgentArgs);
 
     // TODO: check why tsc fails for agent type
-    metadata = await getCanisterInfo(canisterId, (agent as any));
+    metadata = await getCanisterInfo({
+      canisterId,
+      agent: (agent as any),
+    });
   } catch (err) {
     console.warn(`Oops! Metadata for ${canisterId} not found in dab!`);
   }


### PR DESCRIPTION
## Why?

The function signature expects one argument