### PR TITLE
style: 💄 start wide table on wider breakpoint

### DIFF
--- a/packages/dashboard/src/components/Tables/DataTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/DataTable/index.tsx
@@ -65,7 +65,6 @@ const ColWrapper = styled('div', {
   },
 
   '@lg': {
-    // width: '100%',
     width: 'calc(100vw - 320px)',
     padding: '0 10px',
     overflowX: 'scroll',
@@ -165,7 +164,6 @@ const ScrollXContainer = styled('div', {
   },
 
   '@lg': {
-    // width: '100%',
     width: 'calc(100vw - 80px)',
     overflowX: 'hidden',
 


### PR DESCRIPTION
## Why?

The cell values should not break into two lines.

