### PR TITLE
fix: 🐛 release should run on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
   },
   "release": {
     "branches": [
-      "master",
-      "next",
-      "chore/release-process-with-version-support"
+      "main",
+      "next"
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Why?

The release process should run on main branch


