### PR TITLE
chore: 🤖 release should run on main (pre-release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
   },
   "release": {
     "branches": [
-      "master",
-      "next",
-      "chore/release-process-with-version-support"
+      "main",
+      "next"
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Why?

The release process should run on main
