### PR TITLE
chore: 🤖 add workflow target beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - next
+      - beta
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Why?

The workflow should be computed on branch Beta
