### PR TITLE
fix: 🐛 on transaction table, missing nft placeholder image

### DIFF
--- a/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
@@ -219,7 +219,7 @@ const TransactionsTable = ({
       },
       time: (cellValue: string) => dateRelative(cellValue),
     },
-  }), []);
+  }), [identityInDab]);
 
   useEffect(() => {
     setCurrentData(data);

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -113,6 +113,7 @@ const AppTransactions = ({
     })();
   }, [pageData]);
 
+  // TODO: This might be already in cache, if the user comes from Overview
   // Dab metadata handler
   useEffect(() => {
     const getDabMetadataHandler = async () => {      


### PR DESCRIPTION
## Why?

On transaction table, the nft placeholder image is not showing
