### PR TITLE
fix: 🐛 tooltip hover close area

### DIFF
--- a/packages/dashboard/src/components/ItemCell/index.tsx
+++ b/packages/dashboard/src/components/ItemCell/index.tsx
@@ -23,8 +23,10 @@ const ItemCell = styled('div', {
     asHoverState: {
       true: {
         '&:hover': {
-          color: '$purple',
-        },      
+          '& [data-identity-name]': {
+            color: '$purple',
+          },
+        },
       }
     }
   },

--- a/packages/dashboard/src/components/Tooltips/index.tsx
+++ b/packages/dashboard/src/components/Tooltips/index.tsx
@@ -71,11 +71,24 @@ const Tooltip = styled('div', {
       },
     },
   },
+
+  '& [data-hover-placeholder]': {
+    background: 'transparent',
+    width: '180px',
+    height: '100%',
+    position: 'absolute',
+    top: '-50%',
+    left: 0,
+    opacity: 0.2,
+    pointerEvents: 'visible',
+    zIndex: 0,
+  },
 });
 
 export const TableUnknownCellTooltip = () => {
   return (
     <Tooltip data-tooltip>
+      <span data-hover-placeholder />
       <span data-arrow />
       <span data-arrow-after />
       <span data-title>Why is this Unknown?</span>


### PR DESCRIPTION
## Why?

To fix the tooltip which closes as early as it moves out of the unknown area, as expected but needs to persist for longer
