### PR TITLE
fix: 🐛 pagination index computation

### DIFF
--- a/packages/dashboard/src/hooks/store/index.tsx
+++ b/packages/dashboard/src/hooks/store/index.tsx
@@ -350,6 +350,7 @@ export const useTransactionStore = create<TransactionsStore>((set) => ({
     // TODO: If a user request a page that is not the most recent
     // then the total transactions calculation will fail...
     const totalTransactions = PAGE_SIZE * response.page + response.data.length;
+
     const getTotalPages = (totalPages: number) => {
       const count = totalTransactions > PAGE_SIZE ? totalTransactions / PAGE_SIZE : 1;
       // The initial request determinates the total nr of pages
@@ -369,7 +370,10 @@ export const useTransactionStore = create<TransactionsStore>((set) => ({
       // TODO: For totalTransactions/Pages Check TODO above,
       // as total transactions at time of writing
       // can only be computed on first page:None request...
-      totalTransactions,
+      totalTransactions: Math.max(
+        totalTransactions,
+        state.totalTransactions,
+      ),
       totalPages: getTotalPages(state.totalPages),
     }));
   },

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -58,11 +58,17 @@ const AppTransactions = ({
   }) => {
     // Skip initial page because it's handled in the
     // scope of this component useEffect on mount call
-    if (!pageIndex || !rootCanisterId) return;
+    if (typeof pageIndex === 'undefined' || !rootCanisterId) return;
+
+    // Create the page numbers from zero to total pages
+    // and inverse the order to use by the UI page index
+    const pages = Array.from(Array(totalPages).keys()).reverse();
+
+    const page = pages[pageIndex];
 
     await fetch({
       tokenId: rootCanisterId,
-      page: pageIndex,
+      page,
       witness: false,
     });
 

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -62,8 +62,9 @@ const AppTransactions = ({
 
     // Create the page numbers from zero to total pages
     // and inverse the order to use by the UI page index
+    // The page is the formula, but using the array to improve readability
+    // ((totalPages - pageIndex) + 1) - totalPages;
     const pages = Array.from(Array(totalPages).keys()).reverse();
-
     const page = pages[pageIndex];
 
     await fetch({


### PR DESCRIPTION
## Why?

The page index in the UI is different to the Cap Service page. The Service has the oldest page as Zero and the earliest the number of total pages.

