### PR TITLE
style: 💄 explicit selector for colon

### DIFF
--- a/packages/dashboard/src/components/OverallValues/index.tsx
+++ b/packages/dashboard/src/components/OverallValues/index.tsx
@@ -21,7 +21,7 @@ const Overall = styled('div', {
     '& span': {
       paddingRight: '4px',
 
-      '&:first-child:after': {
+      '&[data-name]:after': {
         content: ':',
       },
 
@@ -57,7 +57,7 @@ const OverallValues = ({
         value,
       }) => (
         <div key={name}>
-          <span>{name}</span>
+          <span data-name>{name}</span>
           <span>
             {
               isLoading


### PR DESCRIPTION
## Why?

On loading, a colon is shown in the place of the loading