### PR TITLE
refactor: 💡 dab collection as metadata provider

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import React, {
+  useCallback,
   useEffect,
   useState,
 } from 'react';
@@ -20,7 +21,7 @@ import {
 } from '@hooks/store';
 import { CapRouter } from '@psychedelic/cap-js';
 import { getCapRouterInstance } from '@utils/cap'; 
-import { TokenContractKeyPairedStandard } from '@utils/dab';
+import { TokenContractKeyPairedStandard, DABCollection } from '@utils/dab';
 import config from './config';
 import { LoadableLoadingPlaceholder } from '@components/LoadingForLoadable';
 
@@ -52,11 +53,13 @@ const Routes = ({
   bookmarkExpandHandler,
   loading,
   tokenContractKeyPairedStandard,
+  dabCollection,
 }: {
   bookmarkColumnMode: BookmarkColumnModes,
   bookmarkExpandHandler: BookmarkExpandHandler,
   loading: boolean,
   tokenContractKeyPairedStandard: TokenContractKeyPairedStandard,
+  dabCollection: DABCollection,
 }) => {
   const [capRouterInstance, setCapRouterInstance] = useState<CapRouter | undefined>();
   const accountStore = useAccountStore();
@@ -92,6 +95,7 @@ const Routes = ({
           <LazyOverview
             accountStore={accountStore}
             capRouterInstance={capRouterInstance}
+            dabCollection={dabCollection}
           />
         </Route>
       </Switch>
@@ -100,9 +104,13 @@ const Routes = ({
 }
 
 const App = () => {
+  // At time of writing we get the complete DAB Collection
+  // once the Service changes to support pagination
+  // this will have to change
   const {
     fetchDabCollection,
     tokenContractKeyPairedStandard,
+    dabCollection,
   } = useDabStore();
 
   useEffect(() => {
@@ -114,6 +122,10 @@ const App = () => {
     fetchDabCollection();
   }, []);
 
+  useEffect(() => {
+    console.log('[debug] dabCollection', dabCollection)
+  }, [dabCollection])
+
   return (
     <Router>
       <Routes
@@ -121,6 +133,7 @@ const App = () => {
         bookmarkExpandHandler={() => null}
         loading={false}
         tokenContractKeyPairedStandard={tokenContractKeyPairedStandard}
+        dabCollection={dabCollection}
       />
     </Router>
   );

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import React, {
-  useCallback,
   useEffect,
   useState,
 } from 'react';
@@ -15,12 +14,6 @@ import {
 } from 'react-router-dom';
 import loadable from '@loadable/component';
 import { RouteNames } from '@utils/routes';
-import {
-  useAccountStore,
-  useDabStore,
-  AccountStore,
-  DabStore,
-} from '@hooks/store';
 import { CapRouter } from '@psychedelic/cap-js';
 import { getCapRouterInstance } from '@utils/cap'; 
 import config from './config';
@@ -53,13 +46,9 @@ const Routes = ({
   bookmarkColumnMode,
   bookmarkExpandHandler,
   loading,
-  accountStore,
-  dabStore,
 }: {
   bookmarkColumnMode: BookmarkColumnModes,
   bookmarkExpandHandler: BookmarkExpandHandler,
-  accountStore: AccountStore,
-  dabStore: DabStore,
   loading: boolean,
 }) => {
   const [capRouterInstance, setCapRouterInstance] = useState<CapRouter | undefined>();
@@ -92,8 +81,6 @@ const Routes = ({
         </Route>
         <Route path={RouteNames.Overview}>
           <LazyOverview
-            accountStore={accountStore}
-            dabStore={dabStore}
             capRouterInstance={capRouterInstance}
           />
         </Route>
@@ -102,22 +89,15 @@ const Routes = ({
   );
 }
 
-const App = () => {
-  const dabStore = useDabStore();
-  const accountStore = useAccountStore();
+const App = () => (
+  <Router>
+    <Routes
+      bookmarkColumnMode={BookmarkColumnModes.collapsed}
+      bookmarkExpandHandler={() => null}
+      loading={false}
 
-  return (
-    <Router>
-      <Routes
-        bookmarkColumnMode={BookmarkColumnModes.collapsed}
-        bookmarkExpandHandler={() => null}
-        loading={false}
-        dabStore={dabStore}
-        accountStore={accountStore}
-
-      />
-    </Router>
-  );
-}
+    />
+  </Router>
+);
 
 export default App;

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -18,10 +18,11 @@ import { RouteNames } from '@utils/routes';
 import {
   useAccountStore,
   useDabStore,
+  AccountStore,
+  DabStore,
 } from '@hooks/store';
 import { CapRouter } from '@psychedelic/cap-js';
 import { getCapRouterInstance } from '@utils/cap'; 
-import { TokenContractKeyPairedStandard, DABCollection } from '@utils/dab';
 import config from './config';
 import { LoadableLoadingPlaceholder } from '@components/LoadingForLoadable';
 
@@ -52,17 +53,16 @@ const Routes = ({
   bookmarkColumnMode,
   bookmarkExpandHandler,
   loading,
-  tokenContractKeyPairedStandard,
-  dabCollection,
+  accountStore,
+  dabStore,
 }: {
   bookmarkColumnMode: BookmarkColumnModes,
   bookmarkExpandHandler: BookmarkExpandHandler,
+  accountStore: AccountStore,
+  dabStore: DabStore,
   loading: boolean,
-  tokenContractKeyPairedStandard: TokenContractKeyPairedStandard,
-  dabCollection: DABCollection,
 }) => {
   const [capRouterInstance, setCapRouterInstance] = useState<CapRouter | undefined>();
-  const accountStore = useAccountStore();
 
   useEffect(() => {
     // On App launch, initialises CapRouter instance
@@ -88,14 +88,13 @@ const Routes = ({
         <Route path={RouteNames.AppTransactions}>
           <LazyAppTransactions
             capRouterInstance={capRouterInstance}
-            tokenContractKeyPairedStandard={tokenContractKeyPairedStandard}
           />
         </Route>
         <Route path={RouteNames.Overview}>
           <LazyOverview
             accountStore={accountStore}
+            dabStore={dabStore}
             capRouterInstance={capRouterInstance}
-            dabCollection={dabCollection}
           />
         </Route>
       </Switch>
@@ -104,27 +103,8 @@ const Routes = ({
 }
 
 const App = () => {
-  // At time of writing we get the complete DAB Collection
-  // once the Service changes to support pagination
-  // this will have to change
-  const {
-    fetchDabCollection,
-    tokenContractKeyPairedStandard,
-    dabCollection,
-  } = useDabStore();
-
-  useEffect(() => {
-    // Required to use as a lookup table to
-    // identify the token contract nft standard
-    // at time of writing the getAllNFTs is used
-    // and while this works for now, it's not scalable
-    // as the list increases; a nft registry is under dev
-    fetchDabCollection();
-  }, []);
-
-  useEffect(() => {
-    console.log('[debug] dabCollection', dabCollection)
-  }, [dabCollection])
+  const dabStore = useDabStore();
+  const accountStore = useAccountStore();
 
   return (
     <Router>
@@ -132,8 +112,9 @@ const App = () => {
         bookmarkColumnMode={BookmarkColumnModes.collapsed}
         bookmarkExpandHandler={() => null}
         loading={false}
-        tokenContractKeyPairedStandard={tokenContractKeyPairedStandard}
-        dabCollection={dabCollection}
+        dabStore={dabStore}
+        accountStore={accountStore}
+
       />
     </Router>
   );

--- a/packages/dashboard/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/dashboard/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { styled } from '@stitched';
 import Breadcrumb, { BreadcrumbProps } from '.';
+import { Principal } from '@dfinity/principal';
 
 const Wrapper = styled('div', {
   background: '#000',
@@ -18,17 +19,10 @@ const Template: Story<BreadcrumbProps> = (props) => <Wrapper><Breadcrumb {...pro
 export const Primary = Template.bind({});
 Primary.args = {
   isLoading: false,
-  // identityInDab: {
-  //   name: 'test',
-  //   logo_url: '',
-  //   url: '',
-  //   description: '',
-  //   version: 1,
-  // }
   metadata: {
     icon: '',
     name: '',
     description: '',
-    principal_id: '',
+    principal_id: Principal.fromText('aaaaa-aa'),
   } as any,
 };

--- a/packages/dashboard/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/dashboard/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -18,11 +18,17 @@ const Template: Story<BreadcrumbProps> = (props) => <Wrapper><Breadcrumb {...pro
 export const Primary = Template.bind({});
 Primary.args = {
   isLoading: false,
-  identityInDab: {
-    name: 'test',
-    logo_url: '',
-    url: '',
+  // identityInDab: {
+  //   name: 'test',
+  //   logo_url: '',
+  //   url: '',
+  //   description: '',
+  //   version: 1,
+  // }
+  metadata: {
+    icon: '',
+    name: '',
     description: '',
-    version: 1,
-  }
+    principal_id: '',
+  } as any,
 };

--- a/packages/dashboard/src/components/Breadcrumb/index.tsx
+++ b/packages/dashboard/src/components/Breadcrumb/index.tsx
@@ -4,6 +4,7 @@ import Fleekon from '@components/Fleekon';
 import { RawLink } from '@components/Link';
 import {
   CanisterMetadata,
+  DABCollectionItem,
   DAB_IDENTITY_UNKNOWN,
 } from '@utils/dab';
 import Loading from '@components/Loading';
@@ -51,12 +52,12 @@ const LoadingContainer = styled('span', {
 });
 
 export interface BreadcrumbProps {
-  identityInDab?: CanisterMetadata,
+  metadata?: DABCollectionItem,
   isLoading: boolean,
 }
 
 const Breadcrumb = ({
-  identityInDab,
+  metadata,
   isLoading,
 }: BreadcrumbProps) => {
 
@@ -82,8 +83,8 @@ const Breadcrumb = ({
         : (
           <span>
           {
-            identityInDab
-            ? identityInDab?.name
+            metadata
+            ? metadata?.name
             : DAB_IDENTITY_UNKNOWN
           }
           </span>

--- a/packages/dashboard/src/components/ItemCell/index.tsx
+++ b/packages/dashboard/src/components/ItemCell/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   CanisterMetadata,
   DAB_IDENTITY_UNKNOWN,
+  DABCollectionItem,
 } from '@utils/dab';
 import { styled } from '@stitched';
 import iconUnknown from '@images/icon-unknown.svg';
@@ -45,14 +46,14 @@ const ItemCell = styled('div', {
 export default ({
   cellValue,
   derivedId = true,
-  identityInDab,
+  metadata,
   asHoverState = false,
   nftDetails,
   isLoadingDabItemDetails = false,
 }: {
   cellValue?: number,
   derivedId?: boolean,
-  identityInDab?: CanisterMetadata,
+  metadata?: DABCollectionItem,
   asHoverState?: boolean,
   nftDetails?: NFTDetails,
   isLoadingDabItemDetails?: boolean,
@@ -70,7 +71,7 @@ export default ({
           <span
             data-image
             style={{
-              backgroundImage: `url(${nftDetails?.url || identityInDab?.logo_url || iconUnknown})`,
+              backgroundImage: `url(${nftDetails?.url || metadata?.icon || iconUnknown})`,
               backgroundPosition: 'center',
               backgroundSize: 'cover',
               backgroundRepeat: 'no-repeat',
@@ -81,7 +82,7 @@ export default ({
       }
 
       <span data-identity-name>
-        { identityInDab?.name || DAB_IDENTITY_UNKNOWN }
+        { metadata?.name || DAB_IDENTITY_UNKNOWN }
         {
           // If undefined, hide the cellValue
           derivedId
@@ -92,7 +93,7 @@ export default ({
     </div>
 
     {
-      !identityInDab?.name
+      !metadata?.name
       && (
         <TableUnknownCellTooltip />
       )

--- a/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
@@ -3,7 +3,7 @@ import { styled } from '@stitched';
 // TODO: move the FormatterTypes, Tableid to the util
 import { FormatterTypes, TableId } from '@components/Tables/DataTable';
 import { NamedAccountLink } from '@components/Link';
-import { getDabMetadata, CanisterMetadata } from '@utils/dab';
+import { getDabMetadata, CanisterMetadata, DABCollection, DABCollectionItem } from '@utils/dab';
 import { DabLink } from '@components/Link';
 import ItemCell from '@components/ItemCell';
 import { UnknownItemCell } from '@components/ItemCell';
@@ -45,7 +45,7 @@ export interface AccountData {
   contractId: string,
   dabCanister: {
     contractId: string,
-    metadata?: CanisterMetadata,
+    metadata?: DABCollectionItem,
   },
 }
 
@@ -72,8 +72,10 @@ const columns: Column[] = [
 
 const AccountDab = ({
   canisterId,
+  dabCollection,
 }: {
   canisterId: string,
+  dabCollection: DABCollection,
 }) => {
   const [identityInDab, setIdentityInDab] = useState<CanisterMetadata>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -105,24 +107,31 @@ const AccountDab = ({
     getDabMetadataHandler();
   }, []);
 
-  return (
-    <ItemCell
-      identityInDab={identityInDab}
-      derivedId={false}
-      asHoverState={true}
-    />
-  );
+  console.log('[debug] AccountDab: identityInDab:', identityInDab);
+  console.log('[debug] AccountDab: dabCollection:', dabCollection)
+
+  return <span>Ok</span>;
+
+  // return (
+  //   <ItemCell
+  //     identityInDab={identityInDab}
+  //     derivedId={false}
+  //     asHoverState={true}
+  //   />
+  // );
 };
 
 const AccountsTable = ({
   data = [],
   id,
   isLoading = false,
+  dabCollection,
 }: {
   // eslint-disable-next-line react/require-default-props
   data?: AccountData[],
   id: TableId,
   isLoading: boolean,
+  dabCollection: DABCollection,
 }) => {
   const formatters = useMemo(() => ({
     body: {
@@ -143,7 +152,10 @@ const AccountsTable = ({
               contractId={contractId}
               routeName='AppTransactions'
             >
-              <AccountDab canisterId={contractId} />
+              <AccountDab
+                canisterId={contractId}
+                dabCollection={dabCollection}
+              />
             </UnknownItemCell>
           )
         }

--- a/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
@@ -70,54 +70,6 @@ const columns: Column[] = [
   },
 ];
 
-const AccountDab = ({
-  canisterId,
-}: {
-  canisterId: string,
-}) => {
-  const [identityInDab, setIdentityInDab] = useState<CanisterMetadata>();
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-
-  // Dab metadata handler
-  useEffect(() => {
-    // // TODO: Should this move to the store?
-    // // at the moment is called as a "nice-to-have",
-    // // not as main business logic...
-    // const getDabMetadataHandler = async () => {
-    //   const metadata = await getDabMetadata({
-    //     canisterId,
-    //   });
-
-    //   if (!metadata) {
-    //     setIsLoading(false);
-
-    //     return;
-    //   }
-
-    //   // TODO: Update name column, otherwise fallback
-    //   setIdentityInDab({
-    //     ...metadata,
-    //   });
-
-    //   setIsLoading(false);
-    // };
-
-    // getDabMetadataHandler();
-  }, []);
-
-  console.log('[debug] AccountDab: identityInDab:', identityInDab);
-
-  return <span>Ok</span>;
-
-  // return (
-  //   <ItemCell
-  //     identityInDab={identityInDab}
-  //     derivedId={false}
-  //     asHoverState={true}
-  //   />
-  // );
-};
-
 const AccountsTable = ({
   data = [],
   id,
@@ -139,16 +91,15 @@ const AccountsTable = ({
         metadata?: DABCollectionItem,
       }) => {
         if (!metadata) {
-          // Request the Dab metadata
-          // because we only fetch the very first ones to improve perf
-          // and serve the client ASAP
+          // Displayed as unknown
           return (
             <UnknownItemCell
               contractId={contractId}
               routeName='AppTransactions'
             >
-              <AccountDab
-                canisterId={contractId}
+              <ItemCell
+                derivedId={false}
+                asHoverState={true}
               />
             </UnknownItemCell>
           )

--- a/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
@@ -72,43 +72,40 @@ const columns: Column[] = [
 
 const AccountDab = ({
   canisterId,
-  dabCollection,
 }: {
   canisterId: string,
-  dabCollection: DABCollection,
 }) => {
   const [identityInDab, setIdentityInDab] = useState<CanisterMetadata>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   // Dab metadata handler
   useEffect(() => {
-    // TODO: Should this move to the store?
-    // at the moment is called as a "nice-to-have",
-    // not as main business logic...
-    const getDabMetadataHandler = async () => {
-      const metadata = await getDabMetadata({
-        canisterId,
-      });
+    // // TODO: Should this move to the store?
+    // // at the moment is called as a "nice-to-have",
+    // // not as main business logic...
+    // const getDabMetadataHandler = async () => {
+    //   const metadata = await getDabMetadata({
+    //     canisterId,
+    //   });
 
-      if (!metadata) {
-        setIsLoading(false);
+    //   if (!metadata) {
+    //     setIsLoading(false);
 
-        return;
-      }
+    //     return;
+    //   }
 
-      // TODO: Update name column, otherwise fallback
-      setIdentityInDab({
-        ...metadata,
-      });
+    //   // TODO: Update name column, otherwise fallback
+    //   setIdentityInDab({
+    //     ...metadata,
+    //   });
 
-      setIsLoading(false);
-    };
+    //   setIsLoading(false);
+    // };
 
-    getDabMetadataHandler();
+    // getDabMetadataHandler();
   }, []);
 
   console.log('[debug] AccountDab: identityInDab:', identityInDab);
-  console.log('[debug] AccountDab: dabCollection:', dabCollection)
 
   return <span>Ok</span>;
 
@@ -125,13 +122,11 @@ const AccountsTable = ({
   data = [],
   id,
   isLoading = false,
-  dabCollection,
 }: {
   // eslint-disable-next-line react/require-default-props
   data?: AccountData[],
   id: TableId,
   isLoading: boolean,
-  dabCollection: DABCollection,
 }) => {
   const formatters = useMemo(() => ({
     body: {
@@ -154,7 +149,6 @@ const AccountsTable = ({
             >
               <AccountDab
                 canisterId={contractId}
-                dabCollection={dabCollection}
               />
             </UnknownItemCell>
           )

--- a/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/AccountsTable/index.tsx
@@ -136,7 +136,7 @@ const AccountsTable = ({
         metadata,
       }: {
         contractId: string,
-        metadata?: CanisterMetadata,
+        metadata?: DABCollectionItem,
       }) => {
         if (!metadata) {
           // Request the Dab metadata
@@ -157,7 +157,7 @@ const AccountsTable = ({
         return (
           <DabLink tokenContractId={contractId}>
             <ItemCell
-              identityInDab={metadata}
+              metadata={metadata}
               // Overview page does not requires it
               derivedId={false}
               asHoverState={true}

--- a/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
@@ -11,7 +11,6 @@ import { formatPriceForChart } from '@utils/formatters';
 import Fleekon, { IconNames } from '@components/Fleekon';
 import { getXTCMarketValue } from '@utils/xtc';
 import {
-  CanisterMetadata,
   DABCollectionItem,
   NFTItemDetails,
 } from '@utils/dab';

--- a/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
@@ -12,6 +12,7 @@ import Fleekon, { IconNames } from '@components/Fleekon';
 import { getXTCMarketValue } from '@utils/xtc';
 import {
   CanisterMetadata,
+  DABCollectionItem,
   NFTItemDetails,
 } from '@utils/dab';
 import { toICRocksPrincipal } from '@utils/link';
@@ -176,7 +177,7 @@ const TransactionsTable = ({
   pageCount,
   fetchPageDataHandler,
   isLoading = false,
-  identityInDab,
+  metadata,
   tokenId,
   nftItemDetails,
   isLoadingDabItemDetails,
@@ -187,7 +188,7 @@ const TransactionsTable = ({
   pageCount: number,
   fetchPageDataHandler: FetchPageDataHandler,
   isLoading: boolean,
-  identityInDab?: CanisterMetadata,
+  metadata?: DABCollectionItem,
   tokenId: string,
   nftItemDetails: NFTItemDetails,
   isLoadingDabItemDetails: boolean,
@@ -211,7 +212,7 @@ const TransactionsTable = ({
 
         return (
           <ItemCell
-            identityInDab={identityInDab}
+            metadata={metadata}
             cellValue={cellValue}
             derivedId={true}
             nftDetails={nftDetails}
@@ -249,7 +250,7 @@ const TransactionsTable = ({
       },
       time: (cellValue: string) => dateRelative(cellValue),
     },
-  }), [identityInDab, nftItemDetails, isLoadingDabItemDetails]);
+  }), [metadata, nftItemDetails, isLoadingDabItemDetails]);
 
   useEffect(() => {
     setCurrentData(data);

--- a/packages/dashboard/src/hooks/store/AccountStore.ts
+++ b/packages/dashboard/src/hooks/store/AccountStore.ts
@@ -10,6 +10,7 @@ import {
   CanisterNameKeyPairedId,
   ContractKeyPairedMetadata,
   DABCollectionItem,
+  contractKeyPairedMetadataHandler,
 } from '@utils/dab';
 import { USE_MOCKUP } from './index';
 import { getCapRootInstance } from '@utils/cap';
@@ -143,11 +144,9 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     // which seems that dab-js is missing it and should be updated
     const dabCollection = await fetchDabCollection();
 
-    const contractKeyPairedMetadata = dabCollection?.reduce((acc, curr) => {
-      acc[curr?.principal_id?.toString()] = curr;
-      return acc;
-    }, {} as Record<string, DABCollectionItem>);
+    const contractKeyPairedMetadata = contractKeyPairedMetadataHandler({ dabCollection });
 
+    // TODO: Create parser with related tests, also should validate the pagedata
     pageData = pageData.map(({ contractId, dabCanister }: AccountData) => {
       return ({
         contractId,

--- a/packages/dashboard/src/hooks/store/AccountStore.ts
+++ b/packages/dashboard/src/hooks/store/AccountStore.ts
@@ -164,6 +164,8 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
       return acc;
     }, {} as Record<string, DABCollectionItem>);
 
+    console.log('[debug] AccountStore: contractKeyPairedMetadata: ', contractKeyPairedMetadata);
+
     pageData = pageData.map(({ contractId, dabCanister }: AccountData) => {
       return ({
         contractId,

--- a/packages/dashboard/src/hooks/store/AccountStore.ts
+++ b/packages/dashboard/src/hooks/store/AccountStore.ts
@@ -155,16 +155,14 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     // along the accounts request, as in the future it'll be
     // controlled by the pagination
 
-    const { fetchDabCollection, dabCollection } = dabStore;
+    const { fetchDabCollection } = dabStore;
 
-    await fetchDabCollection();
+    const dabCollection = await fetchDabCollection();
 
     const contractKeyPairedMetadata = dabCollection?.reduce((acc, curr) => {
       acc[curr?.principal_id?.toString()] = curr;
       return acc;
     }, {} as Record<string, DABCollectionItem>);
-
-    console.log('[debug] AccountStore: contractKeyPairedMetadata:', contractKeyPairedMetadata);
 
     pageData = pageData.map(({ contractId, dabCanister }: AccountData) => {
       return ({
@@ -175,8 +173,6 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
         }
       })
     });
-
-    console.log('[debug] AccountStore: pageData:', pageData);
 
     // TODO: seems best not to preload to deliver
     // to the user as it goes or by item loading iteration...

--- a/packages/dashboard/src/hooks/store/AccountStore.ts
+++ b/packages/dashboard/src/hooks/store/AccountStore.ts
@@ -138,6 +138,9 @@ export const useAccountStore = create<AccountStore>((set, get) => ({
     // Fetch the Dab metadata
     const { fetchDabCollection } = dabStore;
 
+    // TODO: invesitgate why the Dab collection which
+    // is returned by the service returns `timestamp`
+    // which seems that dab-js is missing it and should be updated
     const dabCollection = await fetchDabCollection();
 
     const contractKeyPairedMetadata = dabCollection?.reduce((acc, curr) => {

--- a/packages/dashboard/src/hooks/store/AccountStore.ts
+++ b/packages/dashboard/src/hooks/store/AccountStore.ts
@@ -5,12 +5,11 @@ import {
   CapRouter,
   CapRoot,
 } from '@psychedelic/cap-js';
+import { contractKeyPairedMetadataHandler } from '@utils/account';
 import {
   CanisterKeyPairedMetadata,
   CanisterNameKeyPairedId,
   ContractKeyPairedMetadata,
-  DABCollectionItem,
-  contractKeyPairedMetadataHandler,
 } from '@utils/dab';
 import { USE_MOCKUP } from './index';
 import { getCapRootInstance } from '@utils/cap';

--- a/packages/dashboard/src/hooks/store/DabStore.ts
+++ b/packages/dashboard/src/hooks/store/DabStore.ts
@@ -16,12 +16,15 @@ import {
 import {
   Event as TransactionEvent,
 } from '@psychedelic/cap-js';
+import { getDabMetadata, CanisterMetadata } from '@utils/dab';
 
+type TokenContractId = string;
 
 export interface DabStore {
   isLoading: boolean,
   nftItemDetails: NFTItemDetails,
   dabCollection: DABCollection,
+  canisterMetada: CanisterMetadata | undefined,
   tokenContractKeyPairedStandard: TokenContractKeyPairedStandard,
   fetchDabCollection: () => void,
   fetchDabItemDetails: ({
@@ -29,16 +32,19 @@ export interface DabStore {
     tokenId,
     standard,
   }: {
+    // TODO: missing type definition for dab data
     data: any[],
     tokenId: string,
     standard: TokenStandards,
   }) => void,
+  fetchTokenContractDabMetadata: (tokenContractId: TokenContractId) => void,
 }
 
 export const useDabStore = create<DabStore>((set, get) => ({
   isLoading: false,
   nftItemDetails: {},
   dabCollection: [],
+  canisterMetada: undefined,
   tokenContractKeyPairedStandard: {},
   fetchDabCollection: async () => {
     const agent = new HttpAgent({
@@ -105,6 +111,30 @@ export const useDabStore = create<DabStore>((set, get) => ({
     set({
       isLoading: false,
       nftItemDetails: currNftItemDetails,
+    })
+  },
+  fetchTokenContractDabMetadata: async (tokenContactId) => {
+    set({
+      isLoading: true,
+    });
+
+    const canisterMetada = await getDabMetadata({
+      canisterId: tokenContactId,
+    });
+
+    if (!canisterMetada) {
+      console.warn('Oops! Failed to get Dab metadata for Token Contracts')
+
+      set({
+        isLoading: false,
+      });
+
+      return;
+    }
+    
+    set({
+      isLoading: false,
+      canisterMetada,
     })
   },
 }));

--- a/packages/dashboard/src/hooks/store/DabStore.ts
+++ b/packages/dashboard/src/hooks/store/DabStore.ts
@@ -26,7 +26,7 @@ export interface DabStore {
   dabCollection: DABCollection,
   canisterMetada: CanisterMetadata | undefined,
   tokenContractKeyPairedStandard: TokenContractKeyPairedStandard,
-  fetchDabCollection: () => void,
+  fetchDabCollection: () => Promise<DABCollection>,
   fetchDabItemDetails: ({
     data,
     tokenId,
@@ -70,6 +70,8 @@ export const useDabStore = create<DabStore>((set, get) => ({
       tokenContractKeyPairedStandard,
       dabCollection,
     }));
+
+    return dabCollection;
   },
   fetchDabItemDetails: async ({
     data,

--- a/packages/dashboard/src/utils/account.test.ts
+++ b/packages/dashboard/src/utils/account.test.ts
@@ -1,7 +1,13 @@
 import {
   BookmarkColumnModes,
 } from '@components/BookmarkPanel';
-import { createBookmarkExpandHandler, trimAccount } from './account';
+import {
+  createBookmarkExpandHandler,
+  trimAccount,
+  contractKeyPairedMetadataHandler,
+} from './account';
+import { DABCollection } from './dab';
+import { Principal } from '@dfinity/principal';
 import { parseUserRootBucketsResponse } from '@utils/account';
 import { getRandomIdentity } from '@utils/principal';
 
@@ -204,6 +210,56 @@ describe('Account', () => {
           const expectedData = (async () => undefined)();
           expect(parsed).toStrictEqual(expectedData);
         });
+      });
+    });
+  });
+
+  describe('contractKeyPairedMetadataHandler', () => {
+    describe('on valid dab collection', () => {
+      const alicePrincipal = Principal.fromText('sgymv-uiaaa-aaaaa-aaaia-cai');
+      const bobPrincipal = Principal.fromText('ai7t5-aibaq-aaaaa-aaaaa-c');
+      const standard = 'Foobar';
+      const dabCollection: DABCollection = [{
+        description: '',
+        icon: '',
+        name: '',
+        principal_id: alicePrincipal,
+        standard,
+      }, {
+        description: '',
+        icon: '',
+        name: '',
+        principal_id: bobPrincipal,
+        standard,
+      }];
+
+      it('should create a list of token contract-metadata key pair', () => {
+        const contractKeyPairedMetadata = contractKeyPairedMetadataHandler({
+          dabCollection,
+        });
+        const expected = 2;
+
+        expect(
+          Object.keys(contractKeyPairedMetadata).length,
+        ).toBe(expected);
+      });
+
+      it('should have a particular contract', () => {
+        const contractKeyPairedMetadata = contractKeyPairedMetadataHandler({
+          dabCollection,
+        });
+
+        expect(contractKeyPairedMetadata[alicePrincipal.toString()].standard).toBe(standard);
+      });
+    });
+    
+    describe('on invalid dab collection', () => {
+      it('should return an empty object', () => {
+        const contractKeyPairedMetadata = contractKeyPairedMetadataHandler({
+          dabCollection: [],
+        });
+
+        expect(contractKeyPairedMetadata).toStrictEqual({});
       });
     });
   });

--- a/packages/dashboard/src/utils/account.ts
+++ b/packages/dashboard/src/utils/account.ts
@@ -5,6 +5,7 @@ import {
 } from '../components/BookmarkPanel';
 import { Principal } from "@dfinity/principal";
 import { AccountData } from '@components/Tables/AccountsTable';
+import { DABCollection, DABCollectionItem } from './dab';
 
 export const hashTrimmer = (hash: string) => {
   const size = 6;
@@ -98,3 +99,12 @@ export const getTokenContractCanisterIdByRoot = (
 
   return promisedTokenContractsPairedRoots[rootCanisterId];
 }
+
+export const contractKeyPairedMetadataHandler = ({
+  dabCollection,
+}: {
+  dabCollection: DABCollection,
+}) => dabCollection?.reduce((acc, curr) => {
+        acc[curr?.principal_id?.toString()] = curr;
+        return acc;
+      }, {} as Record<string, DABCollectionItem>) || {};

--- a/packages/dashboard/src/utils/dab.ts
+++ b/packages/dashboard/src/utils/dab.ts
@@ -12,12 +12,14 @@ import {
 import { HttpAgent } from '@dfinity/agent';
 import { mockCanisterMetadata } from '@utils/mocks/dabMetadata';
 import { shouldUseMockup } from '@utils/mocks';
+import { ArrayElement } from '@utils/type-defs';
 
 export default {};
 
 export const DAB_CANISTER_ID = 'aipdg-waaaa-aaaah-aaq5q-cai';
 
 export type DABCollection = Awaited<ReturnType<typeof getAllNFTS>>;
+export type DABCollectionItem = ArrayElement<DABCollection>;
 
 export type NFTItemDetails = {
   [tokenContractId: string]: {
@@ -38,7 +40,7 @@ export type ContractPairedMetadata = {
   metadata: CanisterMetadata;
 };
 
-export type ContractKeyPairedMetadata = Record<string, CanisterMetadata>;
+export type ContractKeyPairedMetadata = Record<string, DABCollectionItem>;
 
 export type CanisterKeyPairedMetadata = { [canisterId: string]: CanisterMetadata; };
 export type CanisterNameKeyPairedId = Record<string, string>;

--- a/packages/dashboard/src/utils/dab.ts
+++ b/packages/dashboard/src/utils/dab.ts
@@ -35,11 +35,6 @@ export interface CanisterMetadata {
   logo_url: string;
 }
 
-export type ContractPairedMetadata = {
-  contractId: string;
-  metadata: CanisterMetadata;
-};
-
 export type ContractKeyPairedMetadata = Record<string, DABCollectionItem>;
 
 export type CanisterKeyPairedMetadata = { [canisterId: string]: CanisterMetadata; };

--- a/packages/dashboard/src/utils/images.ts
+++ b/packages/dashboard/src/utils/images.ts
@@ -52,12 +52,12 @@ export const preloadPageDataImages = async ({
   let promises: any = [];
 
   for (let i = 0; i < PRE_FETCH_DAB_INDEX_COUNT; i++) {
-    const logoUrl = pageData[i]?.dabCanister?.metadata?.logo_url;
+    const icon = pageData[i]?.dabCanister?.metadata?.icon;
 
-    if (!logoUrl) continue;
+    if (!icon) continue;
 
     promises.push(
-      preloadImage(logoUrl)
+      preloadImage(icon)
     );
   }
 

--- a/packages/dashboard/src/utils/type-defs.ts
+++ b/packages/dashboard/src/utils/type-defs.ts
@@ -1,0 +1,1 @@
+export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -164,42 +164,42 @@ const AppTransactions = ({
 
   // TODO: This might be already in cache, if the user comes from Overview
   // Dab metadata handler
-  useEffect(() => {
-    const getDabMetadataHandler = async () => {    
-      setIsLoadingDabMetada(true);
+  // useEffect(() => {
+  //   const getDabMetadataHandler = async () => {    
+  //     setIsLoadingDabMetada(true);
 
-      const metadata = await getDabMetadata({
-        canisterId: tokenId,
-      });
+  //     const metadata = await getDabMetadata({
+  //       canisterId: tokenId,
+  //     });
 
-      if (!metadata) {
-        setIsLoadingDabMetada(false);
+  //     if (!metadata) {
+  //       setIsLoadingDabMetada(false);
 
-        return;
-      };
+  //       return;
+  //     };
 
-      // TODO: Update name column, otherwise fallback
-      setIdentityInDab({
-        ...metadata,
-      });
-    };
+  //     // TODO: Update name column, otherwise fallback
+  //     setIdentityInDab({
+  //       ...metadata,
+  //     });
+  //   };
 
-    if (!contractKeyPairedMetadata || !tokenId) {
-      getDabMetadataHandler();
+  //   if (!contractKeyPairedMetadata || !tokenId) {
+  //     getDabMetadataHandler();
 
-      return;
-    };
+  //     return;
+  //   };
 
-    const identityInDab = contractKeyPairedMetadata[tokenId];
+  //   const identityInDab = contractKeyPairedMetadata[tokenId];
 
-    if (!identityInDab) {
-      getDabMetadataHandler();
+  //   if (!identityInDab) {
+  //     getDabMetadataHandler();
 
-      return;
-    };
+  //     return;
+  //   };
 
-    setIdentityInDab(identityInDab);
-  }, [contractKeyPairedMetadata, tokenId]);
+  //   setIdentityInDab(identityInDab);
+  // }, [contractKeyPairedMetadata, tokenId]);
 
   useEffect(() => {
     if (!identityInDab) return;

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -39,10 +39,8 @@ const UserBar = styled('div', {
 
 const AppTransactions = ({
   capRouterInstance,
-  tokenContractKeyPairedStandard,
 }: {
   capRouterInstance: CapRouter | undefined,
-  tokenContractKeyPairedStandard: TokenContractKeyPairedStandard,
 }) => {
   const dabStore = useDabStore();
   const {
@@ -105,8 +103,10 @@ const AppTransactions = ({
   useEffect(() => {
     if (!pageData || !identityInDab) return;
 
+    // TODO: this needs to be refactored inline with latest dab collection changes
     // Should validate if known standard
-    const foundStandard = tokenContractKeyPairedStandard[tokenId];
+    // const foundStandard = tokenContractKeyPairedStandard[tokenId];
+    const foundStandard = '';
 
     if (!isValidStandard(foundStandard)) {
       console.warn(`Oops! Standard ${foundStandard} is unknown`)

--- a/packages/dashboard/src/views/AppTransactions/index.tsx
+++ b/packages/dashboard/src/views/AppTransactions/index.tsx
@@ -19,12 +19,8 @@ import {
 import { scrollTop } from '@utils/window';
 import { styled, BREAKPOINT_DATA_TABLE_L } from '@stitched';
 import {
-  getDabMetadata,
-  CanisterMetadata,
   isValidStandard,
   TokenStandards,
-  TokenContractKeyPairedStandard,
-  DABCollectionItem,
 } from '@utils/dab';
 import IdentityDab from '@components/IdentityDab';
 import OverallValues from '@components/OverallValues';
@@ -57,8 +53,6 @@ const AppTransactions = ({
   } = accountStore;
   const metadata = contractKeyPairedMetadata[tokenId];
   const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingDabMetada, setIsLoadingDabMetada] = useState(true);
-  const [identityInDab, setIdentityInDab] = useState<DABCollectionItem>();
   const isSmallerThanBreakpointLG = useWindowResize({
     breakpoint: BREAKPOINT_DATA_TABLE_L,
   });
@@ -107,9 +101,7 @@ const AppTransactions = ({
   useEffect(() => {
     if (!pageData) return;
 
-    // TODO: this needs to be refactored inline with latest dab collection changes
     // Should validate if known standard
-    // const foundStandard = tokenContractKeyPairedStandard[tokenId];
     const foundStandard = metadata?.standard;
 
     if (!isValidStandard(foundStandard)) {
@@ -165,55 +157,6 @@ const AppTransactions = ({
       setRootCanisterId(rootCanisterId.toText());
     })();
   }, [pageData]);
-
-  // TODO: This might be already in cache, if the user comes from Overview
-  // Dab metadata handler
-  // useEffect(() => {
-  //   const getDabMetadataHandler = async () => {    
-  //     setIsLoadingDabMetada(true);
-
-  //     const metadata = await getDabMetadata({
-  //       canisterId: tokenId,
-  //     });
-
-  //     if (!metadata) {
-  //       setIsLoadingDabMetada(false);
-
-  //       return;
-  //     };
-
-  //     // TODO: Update name column, otherwise fallback
-  //     setIdentityInDab({
-  //       ...metadata,
-  //     });
-  //   };
-
-  //   if (!contractKeyPairedMetadata || !tokenId) {
-  //     getDabMetadataHandler();
-
-  //     return;
-  //   };
-
-  //   const identityInDab = contractKeyPairedMetadata[tokenId];
-
-  //   if (!identityInDab) {
-  //     getDabMetadataHandler();
-
-  //     return;
-  //   };
-
-  //   setIdentityInDab(identityInDab);
-  // }, [contractKeyPairedMetadata, tokenId]);
-
-  // useEffect(() => {
-  //   if (!identityInDab) return;
-
-  //   setIsLoadingDabMetada(false);
-  // }, [identityInDab]);
-
-  useEffect(() => {
-    console.log('[debug] AppTransactions: nftItemDetails: ', nftItemDetails);
-  }, [nftItemDetails]);
 
   return (
     <Page

--- a/packages/dashboard/src/views/Overview/index.tsx
+++ b/packages/dashboard/src/views/Overview/index.tsx
@@ -26,7 +26,11 @@ const Overview = ({
     pageData,
     fetch,    
   } = accountStore;
-  const [pageLoading, setPageLoading] = useState(true);
+  const [pageLoading, setPageLoading] = useState(false);
+
+  useEffect(() => {
+    setPageLoading(true);
+  }, []);
 
   useEffect(() => {
     if (!capRouterInstance) return;
@@ -38,7 +42,11 @@ const Overview = ({
     // once added to Service side, then
     // it should be memoized by the page id
     // TODO: memoize the store selector instead
-    if (pageData.length) return;
+    if (pageData.length) {
+      setPageLoading(false);
+
+      return;
+    }
 
     // Async call
     (async () => {

--- a/packages/dashboard/src/views/Overview/index.tsx
+++ b/packages/dashboard/src/views/Overview/index.tsx
@@ -6,27 +6,26 @@ import AccountsTable from '@components/Tables/AccountsTable';
 import Title from '@components/Title';
 import Page, { PageRow } from '@components/Page';
 import {
-  AccountStore,
-  DabStore,
+  useAccountStore,
+  useDabStore,
 } from '@hooks/store';
 import { CapRouter } from '@psychedelic/cap-js';
 import OverallValues from '@components/OverallValues';
 import SearchInput from '@components/SearchInput';
 
 const Overview = ({
-  accountStore,
   capRouterInstance,
-  dabStore,
 }: {
-  accountStore: AccountStore,
   capRouterInstance: CapRouter | undefined,
-  dabStore: DabStore,
 }) => {
+  const [pageLoading, setPageLoading] = useState(false);
+  const dabStore = useDabStore();
+  const accountStore = useAccountStore();
+
   const {
     pageData,
     fetch,    
   } = accountStore;
-  const [pageLoading, setPageLoading] = useState(false);
 
   useEffect(() => {
     setPageLoading(true);
@@ -52,6 +51,7 @@ const Overview = ({
     (async () => {
       await fetch({
         capRouterInstance,
+        // Optionally, maybe Move this to the fn handler
         dabStore,
       });
 

--- a/packages/dashboard/src/views/Overview/index.tsx
+++ b/packages/dashboard/src/views/Overview/index.tsx
@@ -7,35 +7,29 @@ import Title from '@components/Title';
 import Page, { PageRow } from '@components/Page';
 import {
   AccountStore,
+  DabStore,
 } from '@hooks/store';
 import { CapRouter } from '@psychedelic/cap-js';
 import OverallValues from '@components/OverallValues';
 import SearchInput from '@components/SearchInput';
-import { DABCollection } from '@utils/dab';
 
 const Overview = ({
   accountStore,
   capRouterInstance,
-  dabCollection,
+  dabStore,
 }: {
   accountStore: AccountStore,
   capRouterInstance: CapRouter | undefined,
-  dabCollection: DABCollection,
+  dabStore: DabStore,
 }) => {
   const {
-    isLoading,
     pageData,
     fetch,    
   } = accountStore;
   const [pageLoading, setPageLoading] = useState(true);
 
   useEffect(() => {
-    // At time of writing we get the complete DAB Collection
-    // once the Service changes to support pagination
-    // this will have to change
-    // TODO: The dab collection should be fetched in the account store
-    // as it should be coupled to the account request control by page
-    if (!capRouterInstance || !dabCollection.length) return;
+    if (!capRouterInstance) return;
 
     // If data is ready, interrupt
     // at time of writing the data persists
@@ -43,24 +37,19 @@ const Overview = ({
     // a big number, thus no pagination
     // once added to Service side, then
     // it should be memoized by the page id
+    // TODO: memoize the store selector instead
     if (pageData.length) return;
 
-    fetch({
-      capRouterInstance,
-      dabCollection,
-    });
+    // Async call
+    (async () => {
+      await fetch({
+        capRouterInstance,
+        dabStore,
+      });
 
-    console.log('[debug] Overview: loading: true');
-  }, [capRouterInstance, dabCollection]);
-
-  useEffect(() => {
-    // The OVerview component controls the page load state
-    // instead of relying in the dispatched store loading state
-    if (typeof pageData === 'undefined' || isLoading) return;
-
-    setPageLoading(false);
-    console.log('[debug] Overview: loading: false');
-  }, [pageData])
+      setPageLoading(false);
+    })();
+  }, [capRouterInstance]);
 
   return (
     <Page
@@ -88,7 +77,6 @@ const Overview = ({
           data={pageData}
           id="overview-page-transactions"
           isLoading={pageLoading}
-          dabCollection={dabCollection}
         />
       </PageRow>
     </Page>

--- a/packages/dashboard/src/views/Overview/index.tsx
+++ b/packages/dashboard/src/views/Overview/index.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect } from 'react';
+import React, {
+  useEffect,
+  useState,
+} from 'react';
 import AccountsTable from '@components/Tables/AccountsTable';
 import Title from '@components/Title';
 import Page, { PageRow } from '@components/Page';
@@ -8,31 +11,56 @@ import {
 import { CapRouter } from '@psychedelic/cap-js';
 import OverallValues from '@components/OverallValues';
 import SearchInput from '@components/SearchInput';
+import { DABCollection } from '@utils/dab';
 
 const Overview = ({
   accountStore,
   capRouterInstance,
+  dabCollection,
 }: {
   accountStore: AccountStore,
   capRouterInstance: CapRouter | undefined,
+  dabCollection: DABCollection,
 }) => {
   const {
     isLoading,
     pageData,
     fetch,    
   } = accountStore;
+  const [pageLoading, setPageLoading] = useState(true);
 
   useEffect(() => {
-    if (!capRouterInstance) return;
+    // At time of writing we get the complete DAB Collection
+    // once the Service changes to support pagination
+    // this will have to change
+    // TODO: The dab collection should be fetched in the account store
+    // as it should be coupled to the account request control by page
+    if (!capRouterInstance || !dabCollection.length) return;
 
     // If data is ready, interrupt
+    // at time of writing the data persists
+    // after the initial call, has we don't have
+    // a big number, thus no pagination
+    // once added to Service side, then
+    // it should be memoized by the page id
     if (pageData.length) return;
-    
-    // TODO: cache/memoizing fetch call
+
     fetch({
       capRouterInstance,
+      dabCollection,
     });
-  }, [capRouterInstance]);
+
+    console.log('[debug] Overview: loading: true');
+  }, [capRouterInstance, dabCollection]);
+
+  useEffect(() => {
+    // The OVerview component controls the page load state
+    // instead of relying in the dispatched store loading state
+    if (typeof pageData === 'undefined' || isLoading) return;
+
+    setPageLoading(false);
+    console.log('[debug] Overview: loading: false');
+  }, [pageData])
 
   return (
     <Page
@@ -52,14 +80,15 @@ const Overview = ({
               value: pageData.length,
             },
           ]}
-          isLoading={isLoading}
+          isLoading={pageLoading}
         />
       </PageRow>
       <PageRow>
         <AccountsTable
           data={pageData}
           id="overview-page-transactions"
-          isLoading={isLoading}
+          isLoading={pageLoading}
+          dabCollection={dabCollection}
         />
       </PageRow>
     </Page>


### PR DESCRIPTION
## Why?

Use the Dab Collection as the metadata provider, replacing the previous handling
