### PR TITLE
chore: 🤖 on transaction page landing data state handling

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "webpack serve -c ./webpack/webpack.config.js --node-env development --mode development",
     "dev:development": "yarn start",
-    "dev:production": "IC_HISTORY_ROUTER_ID='lj532-6iaaa-aaaah-qcc7a-cai' MOCKUP=false webpack serve -c ./webpack/webpack.config.js --node-env production --mode production",
+    "dev:production": "IC_HISTORY_ROUTER_ID='lj532-6iaaa-aaaah-qcc7a-cai' USE_WEBPACK_DEV_SERVER=true MOCKUP=false webpack serve -c ./webpack/webpack.config.js --node-env production --mode production",
     "build:production": "webpack -c ./webpack/webpack.config.js --node-env production --mode=production",
     "build:staging": "webpack -c ./webpack/webpack.config.js --node-env staging --mode=production",
     "build:local": "webpack -c ./webpack/webpack.config.js --node-env development --mode=development",

--- a/packages/dashboard/src/hooks/store/TransactionStore.ts
+++ b/packages/dashboard/src/hooks/store/TransactionStore.ts
@@ -11,6 +11,7 @@ import config from '../../config';
 
 export interface TransactionsStore {
   isLoading: boolean,
+  setIsLoading: (isLoading: boolean) => void,
   page: number | undefined,
   pageData: TransactionEvent[] | undefined,
   transactionEvents: TransactionEvent[] | [],

--- a/packages/dashboard/webpack/webpack.config.js
+++ b/packages/dashboard/webpack/webpack.config.js
@@ -11,6 +11,8 @@ const DEFAULT_DEVELOPMENT_ENVIRONMENT = 'development';
 const IS_PROD = process.env.NODE_ENV === 'production';
 const IS_STG = process.env.NODE_ENV === 'staging';
 const IS_DEV = [DEFAULT_DEVELOPMENT_ENVIRONMENT, 'test'].includes(process.env.NODE_ENV);
+const USE_WEBPACK_DEV_SERVER = process.env.USE_WEBPACK_DEV_SERVER === 'true'
+
 // TODO: recently some of the packages made
 // the dashboard project size increase a lot
 // this should be investigated
@@ -93,7 +95,7 @@ let config = {
 };
 
 // Configuration settings for Prod environments
-if (IS_PROD || IS_STG) {
+if (!USE_WEBPACK_DEV_SERVER && (IS_PROD || IS_STG)) {
   config = {
     ...config,
     mode: 'production',
@@ -157,7 +159,7 @@ if (IS_PROD || IS_STG) {
 }
 
 // Configuration settings for Dev environments
-if (IS_DEV) {
+if (IS_DEV || USE_WEBPACK_DEV_SERVER) {
   config = {
     ...config,
     mode: 'development',


### PR DESCRIPTION
## Why?

On transaction page landing, the data state should be handled, otherwise, metadata will not be available.

