### PR TITLE
feat: 🎸 more flexible to/from fields

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "dfx": "0.8.1",
+  "dfx": "0.8.4",
   "defaults": {
     "build": {
       "packtool": ""

--- a/packages/dashboard/src/utils/link.ts
+++ b/packages/dashboard/src/utils/link.ts
@@ -1,3 +1,6 @@
 export default {};
 
-export const toICRocksPrincipal = (id: string) => `https://ic.rocks/principal/${id}`
+export const toICRocksPrincipal = (id: string) => {
+    const path = id.includes('-') ? 'principal' : 'account';
+    return `https://ic.rocks/${path}/${id}`;
+}

--- a/packages/dashboard/src/utils/transactions.ts
+++ b/packages/dashboard/src/utils/transactions.ts
@@ -51,7 +51,7 @@ export const parseGetTransactionsResponse = ({
   if (!data || !Array.isArray(data) || !data.length) return [];
 
   return data.map(v => {
-    const { details } = prettifyCapTransactions(v) as { details : TransactionDetails};
+    const { details } = prettifyCapTransactions(v) as unknown as { details : TransactionDetails};
 
     // TODO: validate details
 
@@ -91,8 +91,8 @@ export const parseGetTransactionsResponse = ({
               tokenField,
             )
             : undefined,
-      to: details?.to?.toText ? details?.to?.toText : details?.to,
-      from: details?.from?.toText ? details?.from?.toText : details?.from,
+      to: details?.to?.toString(),
+      from: details?.from?.toString(),
       amount: details?.amount,
       operation: v.operation,
       time: toTransactionTime(v.time),

--- a/packages/dashboard/src/utils/transactions.ts
+++ b/packages/dashboard/src/utils/transactions.ts
@@ -32,8 +32,8 @@ export const toTransactionTime = (time: bigint) => {
 }
 
 type TransactionDetails = {
-  from: Principal;
-  to: Principal;
+  from: Principal | string;
+  to: Principal | string;
   amount: bigint;
   token?: string;
   tokenId?: string;
@@ -51,7 +51,7 @@ export const parseGetTransactionsResponse = ({
   if (!data || !Array.isArray(data) || !data.length) return [];
 
   return data.map(v => {
-    const { details } = prettifyCapTransactions(v);
+    const { details } = prettifyCapTransactions(v) as { details : TransactionDetails};
 
     // TODO: validate details
 
@@ -87,13 +87,13 @@ export const parseGetTransactionsResponse = ({
       ...v,
       item: tokenField
             ? itemHandler(
-              (details as unknown as TransactionDetails),
+              details,
               tokenField,
             )
             : undefined,
-      to: (details as unknown as TransactionDetails)?.to?.toText(),
-      from: (details as unknown as TransactionDetails)?.from?.toText(),
-      amount: (details as unknown as TransactionDetails)?.amount,
+      to: details?.to?.toText ? details?.to?.toText : details?.to,
+      from: details?.from?.toText ? details?.from?.toText : details?.from,
+      amount: details?.amount,
       operation: v.operation,
       time: toTransactionTime(v.time),
     }


### PR DESCRIPTION
## Why?

The event interface is very loose, and regardless of intention I think it may be possible that developers push a Text AccountIdentifier for the `to` and `from` fields as well as using a Principal type. This simply changes the UI to accept this.

NOTE: I can't properly test this as I can't access the private fleek npm repositories.

## How?

- Changes the `TransactionDetails` type
- Handles the new string | Principal type

## Tickets?

- None

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [x] Documentation has been updated to reflect the changes
- [x] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass
- [x] All tests pass

## Security checklist?

- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The UI is escaping output (to prevent XSS)
- [x] Sensitive data has been identified and is being protected properly

## Demo?

![image](https://user-images.githubusercontent.com/60938577/148483069-a5d8274d-3faa-44fc-898a-b7fac35a0ba2.png)
