### PR TITLE
feat: 🎸 price column

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ To pull and install from [@Psychedelic](https://github.com/psychedelic) via the 
 - A personal access token (you can create a personal acess token [here](https://github.com/settings/tokens))
 - The personal access token with the correct scopes, **repositories**, **org repositories** and **read:packages** to be granted access to the [GitHub Package Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages).
 
-- Authentication via `npm login`, using your Github email for the **username** and the **personal access token** as your **password**:
+- Authentication via `npm login`, using your Github username for the **username** and the **personal access token** as your **password**:
 
 Once you have those ready, run:
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Learn more about [Cap](https://github.com/Psychedelic/cap) by reading the origin
 
 ## 📒 Table of Contents 
 
-- [Requirements](#requirements)
-- [Getting Started](#getting-started)
-  - [Dashboard development](#dashboard-development)
+- [Requirements](#-requirements)
+- [Getting Started](#-getting-started)
+  - [Dashboard development](#-dashboard-development)
   - [The CAP Service](#the-cap-service)
     - [Version control](#cap-service-version-control)
     - [Mock data generator](#cap-service-mock-data-generator)
-- [Build the distribution app](#build-the-distribution-app)
-- [Configure NPM for Github Package Registry](#configure-npm-for-github-package-registry)
-- [Tests](#tests)
-- [Profiler](#profiler)
-- [Contribution guideline](#contribution-guideline)
+- [Build the distribution app](#-build-the-distribution-app)
+- [Configure NPM for Github Package Registry](#-configure-npm-for-github-package-registry)
+- [Tests](#-tests)
+- [Profiler](#-profiler)
+- [Contribution guideline](#-contribution-guideline)
 
 ## ⚙️ Requirements
 

--- a/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
@@ -7,7 +7,7 @@ import { styled } from '@stitched';
 // TODO: move the tableid to the util
 import { TableId } from '@components/Tables/DataTable';
 import { dateRelative } from '@utils/date';
-import { formatPriceForChart } from '@utils/formatters';
+import { formatPriceDetailToString, formatPriceForChart } from '@utils/formatters';
 import Fleekon, { IconNames } from '@components/Fleekon';
 import { getXTCMarketValue } from '@utils/xtc';
 import {
@@ -19,6 +19,7 @@ import { trimAccount } from '@utils/account';
 import ItemCell from '@components/ItemCell';
 import loadable from '@loadable/component';
 import { LoadableLoadingPlaceholder } from '@components/LoadingForLoadable';
+import { Principal } from '@dfinity/principal';
 
 const LazyDatatable = loadable(() => import(/* webpackPrefetch: true */  '@components/Tables/DataTable'), {
   // The fallback to blank is intentional
@@ -105,16 +106,10 @@ export enum TransactionTypes {
   withdraw = 'withdraw',
 }
 
-enum TransactionTypeAlias {
-  all = 'All',
-  deposit = 'Deposit Cycles',
-  withdraw = 'Withdraw Cycles'
-}
-
 export interface Data {
   operation: string,
   item: number,
-  amount: string,
+  price: string,
   from: string,
   to: string,
   time: string,
@@ -135,7 +130,7 @@ export type FetchPageDataHandler = ({
 export const DEFAULT_COLUMN_ORDER: (keyof Data)[] = [
   'item',
   'operation',
-  'amount',
+  'price',
   'from',
   'to',
   'time'
@@ -154,7 +149,7 @@ const columns: Column[] = [
   },
   {
     Header: 'Price',
-    accessor: 'amount',
+    accessor: 'price',
   },
   {
     Header: 'From',
@@ -219,15 +214,14 @@ const TransactionsTable = ({
           />
         );
       },
-      amount: (cellValue: number) => {
-        if (!cellValue || typeof cellValue !== 'bigint') return NOT_AVAILABLE_PLACEHOLDER;
-
-        const usdValue = getXTCMarketValue(cellValue);
-
+      price: (cellValue: {
+        price?: bigint,
+        price_decimals?: bigint,
+        price_currency?: string,
+      }) => {
         return (
           <PriceCell>
-            <div>{formatPriceForChart({ value: usdValue, abbreviation: 'USD' })}</div>
-            <div>{formatPriceForChart({ value: cellValue, abbreviation: 'CYCLES' })}</div>
+            <div>{formatPriceDetailToString(cellValue)}</div>
           </PriceCell>
         );
       },

--- a/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
+++ b/packages/dashboard/src/components/Tables/TransactionsTable/index.tsx
@@ -215,9 +215,9 @@ const TransactionsTable = ({
         );
       },
       price: (cellValue: {
-        price?: bigint,
-        price_decimals?: bigint,
-        price_currency?: string,
+        value?: bigint,
+        decimals?: bigint,
+        currency?: string,
       }) => {
         return (
           <PriceCell>

--- a/packages/dashboard/src/utils/formatters.ts
+++ b/packages/dashboard/src/utils/formatters.ts
@@ -139,9 +139,9 @@ export const formatPriceForChart = ({
   return computedValue;
 };
 
-export const formatPriceDetailToString = (price: { price?: bigint, price_decimals?: bigint, price_currency?: string }) => {
-  if (!price.price) return '-';
-  const divisor = price.price_decimals ? 10 ** Number(price.price_decimals) : 1;
-  const currency = price.price_currency || '';
-  return `${(Number(price.price) / divisor).toFixed(2)} ${currency}`;
+export const formatPriceDetailToString = (price: { value?: bigint, decimals?: bigint, currency?: string }) => {
+  if (!price.value) return '-';
+  const divisor = price.decimals ? 10 ** Number(price.decimals) : 1;
+  const currency = price.currency || '';
+  return `${(Number(price.value) / divisor).toFixed(2)} ${currency}`;
 };

--- a/packages/dashboard/src/utils/formatters.ts
+++ b/packages/dashboard/src/utils/formatters.ts
@@ -138,3 +138,10 @@ export const formatPriceForChart = ({
   computedValue = priceFormatByAbbreviation({ value: computedValue, abbreviation });
   return computedValue;
 };
+
+export const formatPriceDetailToString = (price: { price?: bigint, price_decimals?: bigint, price_currency?: string }) => {
+  if (!price.price) return '-';
+  const divisor = price.price_decimals ? 10 ** Number(price.price_decimals) : 1;
+  const currency = price.price_currency || '';
+  return `${(Number(price.price) / divisor).toFixed(2)} ${currency}`;
+};

--- a/packages/dashboard/src/utils/transactions.ts
+++ b/packages/dashboard/src/utils/transactions.ts
@@ -96,9 +96,9 @@ export const parseGetTransactionsResponse = ({
       to: details?.to?.toString(),
       from: details?.from?.toString(),
       price: {
-        price: details?.price,
-        price_currency: details?.price_currency,
-        price_decimals: details?.price_decimals,
+        value: details?.price,
+        currency: details?.price_currency,
+        decimals: details?.price_decimals,
       },
       operation: v.operation,
       time: toTransactionTime(v.time),

--- a/packages/dashboard/src/utils/transactions.ts
+++ b/packages/dashboard/src/utils/transactions.ts
@@ -34,10 +34,12 @@ export const toTransactionTime = (time: bigint) => {
 type TransactionDetails = {
   from: Principal | string;
   to: Principal | string;
-  amount: bigint;
   token?: string;
   tokenId?: string;
   token_id?: string;
+  price?: bigint;
+  price_decimals?: bigint;
+  price_currency?: string;
 }
 
 type TokenField = 'token' | 'token_id' | 'tokenId';
@@ -93,7 +95,11 @@ export const parseGetTransactionsResponse = ({
             : undefined,
       to: details?.to?.toString(),
       from: details?.from?.toString(),
-      amount: details?.amount,
+      price: {
+        price: details?.price,
+        price_currency: details?.price_currency,
+        price_decimals: details?.price_decimals,
+      },
       operation: v.operation,
       time: toTransactionTime(v.time),
     }


### PR DESCRIPTION
## Why?

Based on conversations in the discord, the expected data underlying the price column has changed. This structure was agreed upon in that channel and has been adopted by Toniq, BTC Flower and Saga:

```
{
    ...
    operation = "sale";
    details = [
        ...
        ("price_decimals", #U64(...)),
        ("price_currency", #Text(...)),
        ("price", #U64(...)),
    ];
}
```

This PR updates the price column in the explorer's transaction table to utilize this structure. After this update, many projects begin showing price data.

## How?

- Update the prettifier method that parses CAP data into table data
- Replace the old `amount` column with price data from the above method
- Add a formatter to turn the price data into a nice string

## Tickets?

- NA

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [x] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

<img width="900" alt="image" src="https://user-images.githubusercontent.com/60938577/154335047-b555abdd-af23-43d3-9e1e-7e564e83f02e.png">
<img width="900" alt="image" src="https://user-images.githubusercontent.com/60938577/154335097-1553746c-e3e2-4378-b2ee-384af62797c1.png">
<img width="904" alt="image" src="https://user-images.githubusercontent.com/60938577/154335184-c9d5b531-862c-4379-a669-3eee2f8adacd.png">
<img width="904" alt="image" src="https://user-images.githubusercontent.com/60938577/154335256-e6fe3290-81f6-4bab-86aa-d0b50a0131e5.png">

