### PR TITLE
Updated all img urls to point to new fleek url

### DIFF
--- a/packages/dashboard/src/index.html
+++ b/packages/dashboard/src/index.html
@@ -8,10 +8,10 @@
     <meta content="CAP is an open internet service that provides an activity and transaction history all assets (Token/NFTs/etc...) on the Internet Computer can integrate to." name="description" />
     <meta content="CAP Explorer - Certified Asset Provenance" property="og:title" />
     <meta content="CAP is an open internet service that provides an activity and transaction history all assets (Token/NFTs/etc...) on the Internet Computer can integrate to." property="og:description" />
-    <meta content="https://storageapi.fleek.co/fleek-team-bucket/logos/cap-meta.png" property="og:image" />
+    <meta content="https://storageapi2.fleek.co/fleek-team-bucket/logos/cap-meta.png" property="og:image" />
     <meta content="CAP Explorer - Certified Asset Provenance" property="twitter:title" />
     <meta content="CAP is an open internet service that provides an activity and transaction history all assets (Token/NFTs/etc...) on the Internet Computer can integrate to." property="twitter:description" />
-    <meta content="https://storageapi.fleek.co/fleek-team-bucket/logos/cap-meta.png" property="twitter:image" />
+    <meta content="https://storageapi2.fleek.co/fleek-team-bucket/logos/cap-meta.png" property="twitter:image" />
     <meta property="og:type" content="website" />
     <meta content="summary_large_image" name="twitter:card" />
   </head>


### PR DESCRIPTION
## Why?
Fake warnings are appearing flagging the page as a possible phishing attack. All img urls pointing to the storage api must be updated to `storageapi2`.

## How?

- Replace img src urls with the correct urls

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
